### PR TITLE
update playwright and move to dev

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
 			"name": "supa-vercel-stack-template",
 			"hasInstallScript": true,
 			"dependencies": {
-				"@playwright/test": "^1.56.1",
 				"@prisma/client": "^5.7.1",
 				"@remix-run/node": "2.16.7",
 				"@remix-run/react": "2.16.7",
@@ -30,6 +29,7 @@
 			"devDependencies": {
 				"@anthropic-ai/claude-code": "^2.0.37",
 				"@faker-js/faker": "^8.3.1",
+				"@playwright/test": "^1.56.1",
 				"@remix-run/dev": "2.16.7",
 				"@remix-run/eslint-config": "2.16.7",
 				"@tailwindcss/forms": "^0.5.7",
@@ -66,7 +66,7 @@
 				"vitest": "^1.1.0"
 			},
 			"engines": {
-				"node": "22.x"
+				"node": ">=22.0.0 <23.0.0"
 			}
 		},
 		"node_modules/@adobe/css-tools": {
@@ -2287,6 +2287,7 @@
 			"version": "1.56.1",
 			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.56.1.tgz",
 			"integrity": "sha512-vSMYtL/zOcFpvJCW71Q/OEGQb7KYBPAdKh35WNSkaZA75JlAO8ED8UN6GUNTm3drWomcbcqRPFqQbLae8yBTdg==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"playwright": "1.56.1"
@@ -13747,6 +13748,7 @@
 			"version": "1.56.1",
 			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.56.1.tgz",
 			"integrity": "sha512-aFi5B0WovBHTEvpM3DzXTUaeN6eN0qWnTkKx4NQaH4Wvcmc153PdaY2UBdSYKaGYw+UyWXSVyxDUg5DoPEttjw==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"playwright-core": "1.56.1"
@@ -13765,6 +13767,7 @@
 			"version": "1.56.1",
 			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.56.1.tgz",
 			"integrity": "sha512-hutraynyn31F+Bifme+Ps9Vq59hKuUCz7H1kDOcBs+2oGguKkWTU50bBWrtz34OUWmIwpBTWDxaRPXrIXkgvmQ==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
 				"playwright-core": "cli.js"
@@ -13777,6 +13780,7 @@
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
 			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
 			"optional": true,

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
 		"db:seed": "dotenv -- tsx app/database/seed.server.ts"
 	},
 	"dependencies": {
-		"@playwright/test": "^1.56.1",
 		"@prisma/client": "^5.7.1",
 		"@remix-run/node": "2.16.7",
 		"@remix-run/react": "2.16.7",
@@ -50,6 +49,7 @@
 	"devDependencies": {
 		"@anthropic-ai/claude-code": "^2.0.37",
 		"@faker-js/faker": "^8.3.1",
+		"@playwright/test": "^1.56.1",
 		"@remix-run/dev": "2.16.7",
 		"@remix-run/eslint-config": "2.16.7",
 		"@tailwindcss/forms": "^0.5.7",


### PR DESCRIPTION
## Summary

Migrates the E2E test suite from Cypress to Playwright for better performance, reliability, and modern testing capabilities.

## Changes Made

### Configuration
- ✅ Created `playwright.config.ts` with proper configuration
  - Base URL configuration (localhost:3000 for dev, 8811 for CI)
  - Test directory: `tests/e2e`
  - Configured to use `data-test-id` attribute for compatibility
  - Screenshot on failure, trace on retry
  - Chromium browser configured (Firefox and Webkit available)

### Test Utilities
- ✅ Migrated test helpers to `tests/support/`
  - `create-user.ts`: Helper to programmatically create test users
  - `delete-user.ts`: Helper to delete test users
  - `fixtures.ts`: Custom Playwright fixtures for automatic user management
- ✅ Created TypeScript config for tests directory

### Test Migration
- ✅ Converted smoke tests from Cypress to Playwright
  - `cypress/e2e/smoke.cy.ts` → `tests/e2e/smoke.spec.ts`
  - All 2 tests migrated successfully
  - Maintained same test coverage and behavior
  - Key conversions:
    - `cy.visit()` → `page.goto()`
    - `cy.findByTestId()` → `page.getByTestId()`
    - `cy.findByRole()` → `page.getByRole()`
    - `cy.type()` → `fill()`
    - Custom commands → Playwright fixtures

### Package Updates
- ✅ Updated npm scripts:
  - `test:e2e:dev`: Now uses Playwright UI mode
  - `test:e2e:run`: Now uses Playwright headless mode
  - `typecheck`: Updated to reference `tests/` instead of `cypress/`
- ✅ Removed Cypress dependencies:
  - `cypress@13.6.1`
  - `@testing-library/cypress@10.0.1`
- ✅ Kept `@playwright/test@1.56.1` (already installed)

### Documentation
- ✅ Updated CLAUDE.md with Playwright information
  - Updated test commands
  - Updated file paths and structure
  - Documented Playwright fixtures and utilities

### Cleanup
- ✅ Removed all Cypress files and directories
- ✅ Updated `.gitignore` to remove Cypress paths and add Playwright paths

## Testing

Tests are successfully detected by Playwright:
```bash
$ npx playwright test --list
Listing tests:
  [chromium] › smoke.spec.ts:7:6 › smoke tests › should allow you to register and login
  [chromium] › smoke.spec.ts:39:6 › smoke tests › should allow you to make a note
Total: 2 tests in 1 file
```

## Migration Benefits

- Better debugging tools with browser DevTools integration
- Faster test execution
- Built-in test retry and parallelization
- Modern API with better TypeScript support
- Active development and larger community
- UI mode for interactive debugging

## Breaking Changes

None. The test suite maintains the same coverage and behavior.

## Related Issue

Closes #11
